### PR TITLE
Add include to config.hpp in dSFMT.hpp

### DIFF
--- a/sampling/rng/dSFMT.hpp
+++ b/sampling/rng/dSFMT.hpp
@@ -54,6 +54,8 @@
 
 #pragma once
 
+#include "../config.hpp"
+
 #include <tlx/logger.hpp>
 #include <tlx/define.hpp>
 


### PR DESCRIPTION
`w128_t` defined in `dSFMT.hpp` has different alignment depending on whether `dSFMT.hpp` gets included before or after `config.hpp` (since it depends on `SAMPLING_HAVE_SSE2`). Currently, this is not always consistent